### PR TITLE
make linux terminal drag and drop work

### DIFF
--- a/src/main/java/de/theminefighter/stslauncher/Main.java
+++ b/src/main/java/de/theminefighter/stslauncher/Main.java
@@ -85,6 +85,7 @@ public class Main {
         System.out.println("Please enter the path of the jnlp to launch");
         BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
         String str = reader.readLine();
+		str = str.replace("\"", "").replace("'", "").trim();
         if (str.length()==0) {
             System.out.println("No file provided. Exiting");
             return null;


### PR DESCRIPTION
A file dragged into a linux terminal is sometimes put in quotations. This PR removes them before further processing.