### PR TITLE
fix #18 `codebase` was not always correctly initialized and used

### DIFF
--- a/src/main/java/de/theminefighter/stslauncher/JavaUtilities.java
+++ b/src/main/java/de/theminefighter/stslauncher/JavaUtilities.java
@@ -1,18 +1,13 @@
 package de.theminefighter.stslauncher;
 
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.file.Paths;
 
 /**
  * Some Java utility methods
  */
 public class JavaUtilities {
-	public static URI codebase;
-
 	/**
 	 * Determines the path of the java executable running
 	 *
@@ -43,14 +38,4 @@ public class JavaUtilities {
 		return !getStsLauncherLocation().isDirectory();
 	}
 
-	public static URL resolveHref(String href) {
-		try {
-			if (codebase == null) {
-				return new URL(href);
-			}
-			return codebase.resolve(href).toURL();
-		} catch (MalformedURLException e) {
-			throw new RuntimeException(e);
-		}
-	}
 }

--- a/src/main/java/de/theminefighter/stslauncher/JnlpLauncher.java
+++ b/src/main/java/de/theminefighter/stslauncher/JnlpLauncher.java
@@ -11,7 +11,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URL;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -54,9 +53,6 @@ public class JnlpLauncher {
 	static String[] prepareLaunch(String jnlp, boolean slf) throws Exception {
 		//load jnlp structure
 		Element root = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new File(jnlp)).getDocumentElement();
-		if (root.hasAttribute("codebase")) {
-			JavaUtilities.codebase = new URI(root.getAttribute("codebase"));
-		}
 		Element resources = (Element) root.getElementsByTagName("resources").item(0);
 		Element appDesc = (Element) root.getElementsByTagName("application-desc").item(0);
 		//load server addresses and other stuff from jnlp to system properties
@@ -160,7 +156,7 @@ public class JnlpLauncher {
 		NodeList jars = resources.getElementsByTagName("jar");
 		for (int i = 0; i < jars.getLength(); i++) {
 			Element jar = (Element) jars.item(i);
-			URL href = JavaUtilities.resolveHref(jar.getAttribute("href"));
+			URL href = JWSContext.resolveHref(jar.getAttribute("href"));
 			File cached = cache.get(href, Flags.offline);
 			jarsToLoad.add(cached);
 		}

--- a/src/main/java/de/theminefighter/stslauncher/Main.java
+++ b/src/main/java/de/theminefighter/stslauncher/Main.java
@@ -24,7 +24,8 @@ public class Main {
 		String jnlpPath = args[0];
 		System.setProperty("jnlpx.origFilenameArg", jnlpPath);
 		//Only now JWSContext may be loaded
-		URL jnlpUrl=new URL( JWSContext.getRoot().getAttribute("href"));
+		String href = JWSContext.getRoot().getAttribute("href");
+		URL jnlpUrl= JWSContext.resolveHref(href);
 		boolean launchedBefore=JWSContext.getCache().has(jnlpUrl);
 		if (!launchedBefore) {
 			createRequestedShortcuts();


### PR DESCRIPTION
Previously the `codebase` var was only initialized inside `prepareLaunch` which resulted in it being `null` at runtime of the jnlp. But in some cases `resolveHref` is needed at runtime (for example when creating a shortcut and determining the icon file to use.

This MR moves `codebase` and `resolveHref` to `JWSContext` and the initialization of the codebase variable into it's `ini` method. This ensures that `codebase` is always correctly filled (as `ini` is called by the the classloader).